### PR TITLE
feat(comments): gate comment form behind auth and add login prompt

### DIFF
--- a/templates/blog/article.html.twig
+++ b/templates/blog/article.html.twig
@@ -52,36 +52,49 @@
             {% else %}
                 <p>Aucun commentaire pour le moment.</p>
             {% endif %}
-            
+
             <div class="comment-form form-container">
                 <h4>Ajouter un commentaire</h4>
-                
+
                 {% if commentSuccess %}
                     <div class="alert alert-success">
                         Votre commentaire a été soumis et sera publié après validation.
                     </div>
                 {% endif %}
-                
-                {% if errors|length > 0 %}
-                    <div class="alert alert-danger">
-                        <ul>
-                            {% for error in errors %}
-                                <li>{{ error }}</li>
-                            {% endfor %}
-                        </ul>
+
+                {% if not user %}
+                    <div class="alert alert-info mb-3 ">
+                        Vous devez être connecté pour poster un commentaire.
                     </div>
+                    <a class="btn btn-primary" href="/login">
+                        Se connecter
+                    </a>
+                    <a class="btn btn-danger" href="/register">
+                        Créer un compte
+                    </a>
+                {% else %}
+                    {# Utilisateur connecté : afficher le formulaire #}
+                    {% if errors|length > 0 %}
+                        <div class="alert alert-danger">
+                            <ul>
+                                {% for error in errors %}
+                                    <li>{{ error }}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    <form method="post">
+                        {{ csrf_field() }}
+
+                        <div class="form-group mb-3">
+                            <label for="content">Commentaire</label>
+                            <textarea class="form-control" id="content" name="content" rows="4" required></textarea>
+                        </div>
+
+                        <button type="submit" class="btn btn-primary">Soumettre</button>
+                    </form>
                 {% endif %}
-                
-                <form method="post">
-                    {{ csrf_field() }}
-                    
-                    <div class="form-group mb-3">
-                        <label for="content">Commentaire</label>
-                        <textarea class="form-control" id="content" name="content" rows="4" required></textarea>
-                    </div>
-                    
-                    <button type="submit" class="btn btn-primary">Soumettre</button>
-                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
feat(comments): gate comment form behind auth and add login prompt

- Show info message and “Sign in” button for unauthenticated users
- Hide comment form for guests; display it only when the user is logged in
- Add “Create account” link for new users